### PR TITLE
Fix: Updating the Installation link to go to /docs

### DIFF
--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -149,7 +149,7 @@ Here the same example deployed: https://vue-mailgo.mailgo.dev
 
 ## Hugo
 
-[Standard installation methods](/docs/installation) are supported. The simplest solution is to install mailgo into one of your content files (a post or page) using the CDN method since anything added in the content markdown file is included in the content page body on site generation.
+[Standard installation methods](/docs/) are supported. The simplest solution is to install mailgo into one of your content files (a post or page) using the CDN method since anything added in the content markdown file is included in the content page body on site generation.
 
 ```
 ---

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -23,7 +23,7 @@ class Footer extends React.Component {
           </a>
           <div>
             <h5>Docs</h5>
-            <a href={"/docs/installation"}>Installation</a>
+            <a href={"/docs/"}>Installation</a>
             <a href={"/docs/usage"}>Usage (mailto:)</a>
             <a href={"/docs/usage-tel"}>Usage (tel:)</a>
             <a href={"/docs/configuration"}>Configuration</a>


### PR DESCRIPTION
It did go to /docs/Installation but that returns a 404.

Edit: I think it might need a rebuild or something to correct to link (`/build` is in version control, but I think Netlify can cache that).